### PR TITLE
Update Automated Builds, push to GHCR and DockerHub

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -32,12 +32,10 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
-        id: meta
+        id: meta-ghcr
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: |
-            ${{ env.REGISTRY_GITHUB }}/${{ env.IMAGE_NAME }}
-            ${{ env.REGISTRY_DOCKERHUB }}/${{ github.actor }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY_GITHUB }}/${{ env.IMAGE_NAME }}
 
 
       - name: Build and push Docker image to GitHub
@@ -45,8 +43,8 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-ghcr.outputs.tags }}
+          labels: ${{ steps.meta-ghcr.outputs.labels }}
       
       - name: Log in to DockerHub
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
@@ -55,10 +53,16 @@ jobs:
           username: ${{ env.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }} # You need to set this secret in your GitHub repository settings
 
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta-dh
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY_DOCKERHUB }}/${{ github.actor }}/${{ env.IMAGE_NAME }}
+
       - name: Build and push Docker image to DockerHub
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-dh.outputs.tags }}
+          labels: ${{ steps.meta-dh.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,7 +9,8 @@ on:
   push:
 
 env:
-  REGISTRY: ghcr.io
+  REGISTRY_GITHUB: ghcr.io
+  REGISTRY_DOCKERHUB: docker.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
@@ -23,10 +24,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Log in to the Container registry
+      - name: Log in to the GHCR
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ${{ env.REGISTRY_GITHUB }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -34,9 +35,27 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: |
+            ${{ env.REGISTRY_GITHUB }}/${{ env.IMAGE_NAME }}
+            ${{ env.REGISTRY_DOCKERHUB }}/${{ github.actor }}/${{ env.IMAGE_NAME }}
 
-      - name: Build and push Docker image
+
+      - name: Build and push Docker image to GitHub
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      
+      - name: Log in to DockerHub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY_DOCKERHUB }}
+          username: ${{ env.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }} # You need to set this secret in your GitHub repository settings
+
+      - name: Build and push Docker image to DockerHub
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -57,7 +57,7 @@ jobs:
         id: meta-dh
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY_DOCKERHUB }}/${{ github.actor }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY_DOCKERHUB }}/DonairSauce/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image to DockerHub
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -56,7 +56,7 @@ jobs:
         id: meta-dh
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY_DOCKERHUB }}/DonairSauce/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY_DOCKERHUB }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image to DockerHub
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,7 +1,5 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
+# The purpose of this GitHub Action is to build & push the docker container
+# Once built, the container will be pushed to GitHub Contariner Registry, and then DockerHub
 
 name: Create and publish a Docker image
 
@@ -25,7 +23,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Log in to the GHCR
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY_GITHUB }}
           username: ${{ github.actor }}
@@ -33,15 +31,14 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta-ghcr
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_GITHUB }}/${{ env.IMAGE_NAME }}
 
 
       - name: Build and push Docker image to GitHub
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v5
         with:
-          context: .
           push: true
           tags: ${{ steps.meta-ghcr.outputs.tags }}
           labels: ${{ steps.meta-ghcr.outputs.labels }}
@@ -54,14 +51,13 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta-dh
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_DOCKERHUB }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image to DockerHub
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v5
         with:
-          context: .
           push: true
           tags: ${{ steps.meta-dh.outputs.tags }}
           labels: ${{ steps.meta-dh.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -47,11 +47,10 @@ jobs:
           labels: ${{ steps.meta-ghcr.outputs.labels }}
       
       - name: Log in to DockerHub
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY_DOCKERHUB }}
-          username: ${{ env.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }} # You need to set this secret in your GitHub repository settings
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta-dh


### PR DESCRIPTION
This PR primarily addresses the need to have containers pushed to DockerHub, in addition to GHCR. 

I've also updated our action to use newer versions of the referenced methods, to make things cleaner. Secrets have been added to the repo with the DockerHub token to enable automated builds.

Resolves #43 